### PR TITLE
v0.2.0-beta.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,6 @@ build-zfs-7:
 
 	@rm -f go.mod go.sum Dockerfile
 
-test:
-	go test ./...
 
 lint:
 	golint ./...
@@ -41,9 +39,6 @@ fmt:
 clean:
 	@rm -f go.mod go.sum Dockerfile
 	@rm -rf artifacts/*
-
-quick:
-	go build -o zfsmon
 
 prune-docker:
 	docker system prune --force

--- a/alert/relay/relay.go
+++ b/alert/relay/relay.go
@@ -1,12 +1,12 @@
 package relay
 
 import (
-    "fmt"
     "net/http"
     "encoding/json"
     "bytes"
     "strconv"
     "io/ioutil"
+    "time"
 
     "github.com/pkg/errors"
 )
@@ -37,9 +37,6 @@ func (relay Relay) Message(message string) error {
         return err
     }
 
-    fmt.Println(relay.BaseURL, relay.APIKey)
-    fmt.Println(string(b))
-
     req, err := http.NewRequest("POST", relay.BaseURL + "/message", bytes.NewBuffer(b))
     if err != nil {
         return err
@@ -47,13 +44,16 @@ func (relay Relay) Message(message string) error {
     req.Header.Set("Content-Type", "application/json")
     req.Header.Set(apiKeyHeader, relay.APIKey)
 
+    return send(req)
+}
+
+func send(req *http.Request) error {
     client := &http.Client{}
     resp, err := client.Do(req)
     if err != nil {
-        return err
+        return nil
     }
     defer resp.Body.Close()
-
     if resp.StatusCode != 200 {
         body, _ := ioutil.ReadAll(resp.Body)
         if body == nil {

--- a/alert/relay/relay.go
+++ b/alert/relay/relay.go
@@ -6,7 +6,6 @@ import (
     "bytes"
     "strconv"
     "io/ioutil"
-    "time"
 
     "github.com/pkg/errors"
 )

--- a/alert/relay/relay_test.go
+++ b/alert/relay/relay_test.go
@@ -1,0 +1,29 @@
+package relay
+
+import (
+    "testing"
+)
+
+func TestMessagE(t *testing.T) {
+    r := Relay{}
+    if r.Message("") == nil {
+        t.Errorf("relay.Message() should return an error when given an empty message")
+    }
+}
+
+func TestInit(t *testing.T) {
+    // uses a random uuid
+    r := Relay{
+        BaseURL: "",
+        APIKey: "93733f41-2952-4ecc-a36c-c32782ca5ce5",
+    }
+
+    if err := r.init(); err != nil {
+        t.Errorf(err.Error())
+        return
+    }
+
+    if r.BaseURL != DefaultBaseURL {
+        t.Errorf("expected base url to be set by init when empty")
+    }
+}

--- a/build/zfs7/Dockerfile
+++ b/build/zfs7/Dockerfile
@@ -15,8 +15,8 @@ RUN apt-get install -y \
     zip \
 	git \
     gcc \
-	zfsutils-linux=0.7.5-1ubuntu16.8 \
-	libzfslinux-dev=0.7.5-1ubuntu16.8
+	zfsutils-linux=0.7.5-1ubuntu16.9 \
+	libzfslinux-dev=0.7.5-1ubuntu16.9
 
 WORKDIR /zfsmon
 COPY . .

--- a/build/zfs7/go.mod.zfs.7
+++ b/build/zfs7/go.mod.zfs.7
@@ -6,6 +6,7 @@ require (
 	// v10 release
 	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/google/uuid v1.1.1
 
 	github.com/hashicorp/go-multierror v1.0.0
 	// zfs 7.x bindings

--- a/build/zfs7/go.sum.zfs.7
+++ b/build/zfs7/go.sum.zfs.7
@@ -35,6 +35,8 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"github.com/jsirianni/zfsmon/cmd"
 )
 
-const VERSION = "0.2.0"
+const VERSION = "0.2.0-beta.1"
 
 func main() {
 	cmd.Execute()

--- a/zfs/alert.go
+++ b/zfs/alert.go
@@ -1,6 +1,7 @@
 package zfs
 
 import (
+    "time"
     "github.com/pkg/errors"
 )
 
@@ -30,7 +31,11 @@ func (z Zfs) sendAlert(pool Zpool, healthy bool) error {
 	}
 
 	if err := z.Alert.Message(msg); err != nil {
-		return errors.Wrap(err, "failed to send alert")
+        z.Log.Error(errors.Wrap(err, "will try again in five seconds"))
+        time.Sleep(time.Second * 5)
+        if err := z.Alert.Message(msg); err != nil {
+            return errors.Wrap(err, "failed to send alert")
+        }
 	}
 	return nil
 }


### PR DESCRIPTION
- added uuid check to relay alert plugin
- added tests to relay alert plugin
- added basic retry logic when sending alerts, will attempt to send the alert a second time after five seconds. Not really a big deal because a failed disk is not written to the state until the alert is sent successfully, so zfsmon would try again eventually. 